### PR TITLE
Pin GitHub PR action to commit hash

### DIFF
--- a/.github/workflows/openclaw-release-pr.yml
+++ b/.github/workflows/openclaw-release-pr.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Create or update pull request
         if: steps.versions.outputs.update_needed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: bot/openclaw-update-${{ steps.versions.outputs.latest_version }}


### PR DESCRIPTION
To avoid attacks on compromised actions.