### PR TITLE
chore: skip OpenClaw hook setup during onboarding

### DIFF
--- a/server.cjs
+++ b/server.cjs
@@ -669,6 +669,7 @@ wss.on("connection", (ws) => {
     "--skip-daemon",
     "--skip-ui",
     "--skip-health",
+    "--skip-hooks",
     "--mode", "local",
     "--gateway-port", OPENCLAW_PORT.toString(),
   ], {


### PR DESCRIPTION
## Summary
- Pass `--skip-hooks` to `openclaw onboard` during Umbrel setup
- Keeps Umbrel onboarding focused on provider/API-key selection and skips OpenClaw's default internal hook setup

## Test Plan
- `npm ci --omit=dev`
- `node --check server.cjs`
- Static assertion that onboarding args include `--skip-hooks` before `--mode local`
- Verified `openclaw@2026.5.28 onboard --help` includes `--skip-hooks`
