### PR TITLE
chore: remove stale hooks setup copy

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -429,7 +429,7 @@
       <div class="terminal-info">
         <div class="info-heading">Starting OpenClaw setup...</div>
         <div class="info-dim">You'll be asked to choose an AI provider and enter your API key.</div>
-        <div class="info-dim">This may take a moment to appear. When asked about hooks, you can skip for now.</div>
+        <div class="info-dim">This may take a moment to appear.</div>
       </div>
       <div class="terminal-body">
         <div id="terminal"></div>


### PR DESCRIPTION
## Summary
- Remove stale setup UI guidance telling users to manually skip hooks
- Keep the setup copy aligned with the new `--skip-hooks` onboarding flag

## Test Plan
- `npm ci --omit=dev`
- `node --check server.cjs`
- `git diff --check`
- Searched for stale hook-skip guidance; only the actual `--skip-hooks` flag remains
