### PR TITLE
fix: support suffixed OpenClaw releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          tag=$(grep -oE 'openclaw@[0-9]+(\.[0-9]+)*' Dockerfile | head -n1 | cut -d'@' -f2)
+          tag=$(node -e 'const fs = require("fs"); const match = fs.readFileSync("Dockerfile", "utf8").match(/npm install -g openclaw@([^\s\\]+)/); if (!match) process.exit(1); process.stdout.write(match[1]);')
           echo "TAG=${tag}" >> "$GITHUB_ENV"
 
       - name: Set TAG from pushed ref

--- a/.github/workflows/openclaw-release-pr.yml
+++ b/.github/workflows/openclaw-release-pr.yml
@@ -26,9 +26,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          current_version=$(grep -oE 'openclaw@[0-9]+(\.[0-9]+)*' Dockerfile | head -n1 | cut -d'@' -f2)
-          all_versions=$(npm view openclaw versions --json)
-          latest_version=$(node -e 'const versions = JSON.parse(process.argv[1]); const list = Array.isArray(versions) ? versions : [versions]; const stable = list.filter(v => !v.includes("-")); if (!stable.length) { process.exit(1); } console.log(stable[stable.length - 1]);' "$all_versions")
+          current_version=$(node -e 'const fs = require("fs"); const match = fs.readFileSync("Dockerfile", "utf8").match(/npm install -g openclaw@([^\s\\]+)/); if (!match) process.exit(1); process.stdout.write(match[1]);')
+          latest_version=$(npm view openclaw@latest version)
 
           echo "current_version=${current_version}" >> "$GITHUB_OUTPUT"
           echo "latest_version=${latest_version}" >> "$GITHUB_OUTPUT"
@@ -42,10 +41,23 @@ jobs:
       - name: Update Dockerfile OpenClaw version
         if: steps.versions.outputs.update_needed == 'true'
         shell: bash
+        env:
+          LATEST_OPENCLAW_VERSION: ${{ steps.versions.outputs.latest_version }}
         run: |
           set -euo pipefail
-          latest="${{ steps.versions.outputs.latest_version }}"
-          sed -i -E "s|(npm install -g openclaw@)[0-9]+(\.[0-9]+)*|\\1${latest}|" Dockerfile
+          node <<'NODE'
+          const fs = require("fs");
+          const path = "Dockerfile";
+          const version = process.env.LATEST_OPENCLAW_VERSION;
+          const source = fs.readFileSync(path, "utf8");
+          const pattern = /(npm install -g openclaw@)[^\s\\]+/;
+
+          if (!version || !pattern.test(source)) {
+            throw new Error("Unable to update the pinned OpenClaw version");
+          }
+
+          fs.writeFileSync(path, source.replace(pattern, (_, prefix) => `${prefix}${version}`));
+          NODE
 
       - name: Create or update pull request
         if: steps.versions.outputs.update_needed == 'true'

--- a/.github/workflows/tag-on-openclaw-merge.yml
+++ b/.github/workflows/tag-on-openclaw-merge.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          version=$(grep -oE 'openclaw@[0-9]+(\.[0-9]+)*' Dockerfile | head -n1 | cut -d'@' -f2)
+          version=$(node -e 'const fs = require("fs"); const match = fs.readFileSync("Dockerfile", "utf8").match(/npm install -g openclaw@([^\s\\]+)/); if (!match) process.exit(1); process.stdout.write(match[1]);')
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Create tag if missing


### PR DESCRIPTION
Fix the automated OpenClaw release flow for stable npm versions with suffixes such as `2026.7.1-2`.

- follow npm's official `latest` dist-tag
- preserve the full version while updating the Dockerfile
- preserve suffixes in Git and container tags

Validation:
- exercised base-to-suffix, suffix-to-base, and suffix-to-suffix replacements
- parsed all modified workflow files as YAML
- `git diff --check`