### PR TITLE
feat: add authenticated native gateway access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,4 +73,4 @@ ENV PATH="/data/.npm-global/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.
 
 # Run the setup/proxy server
 CMD ["node", "/app/setup-server.cjs"]
-EXPOSE 18789
+EXPOSE 18789 18791

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This is a containerized version of OpenClaw with seamless onboarding on umbrelOS
 - apt/apt-get disabled with a message telling openclaw to use brew instead
 - Globally installed node modules persisted between app updates
 - One-click Control UI access through Umbrel's authenticated proxy, with same-origin browser checks and automatic browser device enrollment
+- Direct native Gateway connections over a private LAN or Tailnet, protected by the app's deterministic password and explicit device pairing
 - Container-owned Gateway supervision and updates, with OpenClaw self-updates disabled
 
 This creates a seamless one click install experience for OpenClaw on umbrelOS.
@@ -33,13 +34,27 @@ Origin against the original Host and protocol before forwarding HTTP or WebSocke
 requests. Umbrel's proxy must preserve Host and set `X-Forwarded-Proto` when
 terminating TLS.
 
+A separate WebSocket-only listener on `18791` is intended for native clients.
+It strips proxy identity, forwarding, cookie, and HTTP authorization headers and
+never grants the Umbrel owner's browser identity. Clients must authenticate with
+the deterministic app password shown in Umbrel's app settings, then complete
+OpenClaw device and node-capability pairing. Plain HTTP requests to this listener
+receive `426 Upgrade Required`.
+
 On upgrade, the wrapper removes the retired device-auth flags and shared Gateway
 token, enables trusted-proxy browser authentication, and provisions a persistent
-password for direct internal CLI/RPC clients. Browser device enrollment grants
+password for direct CLI/RPC and native clients. On Umbrel the password is rotated
+to the app's deterministic password so the owner can retrieve it from app
+settings. Browser device enrollment grants
 ordinary UI scopes; admin access is granted to the verified Umbrel identity on
 each connection. Gateway proxy requests from loopback are rejected because they
 cannot provide a non-loopback proxy peer; internal clients should use OpenClaw's
 CLI or the internal Gateway port with its password.
+
+The native listener is suitable for trusted private networks such as a home LAN
+or Tailnet. Do not forward it directly to the public Internet: `ws://` is
+unencrypted and the Gateway is a high-authority control surface. Use a properly
+authenticated TLS endpoint (`wss://`) if public-network access is required.
 
 ## Tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,15 @@ services:
     init: true
     environment:
       APP_SEED: ${APP_SEED:-dev} # Provided by umbrelOS; fallback for local dev
+      UMBREL_OPENCLAW_REMOTE_PASSWORD: ${APP_PASSWORD:?Set APP_PASSWORD before starting the native Gateway listener}
+      NATIVE_GATEWAY_PORT: 18791
       OPENCLAW_STATE_DIR: /data/.openclaw
       OPENCLAW_SERVICE_REPAIR_POLICY: external
       OPENCLAW_SUPERVISOR_MODE: external
       OPENCLAW_NO_RESPAWN: "1"
     ports:
       - "18789:18789"
+      - "18791:18791"
     volumes:
       - $PWD/data:/data
       - $PWD/data/linuxbrew:/home/linuxbrew

--- a/server.cjs
+++ b/server.cjs
@@ -15,6 +15,9 @@ const CONFIG_FILE = path.join(CONFIG_DIR, "openclaw.json");
 const ENV_FILE = path.join(CONFIG_DIR, ".env");
 const PORT = parseInt(process.env.SETUP_PORT || "18789");
 const OPENCLAW_PORT = 18790; // Internal port for OpenClaw gateway
+const NATIVE_GATEWAY_PORT = parseInt(process.env.NATIVE_GATEWAY_PORT || "18791");
+const GATEWAY_MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
+const GATEWAY_MAX_PREAUTH_PAYLOAD_BYTES = 64 * 1024;
 const GATEWAY_HOST = `127.0.0.1:${OPENCLAW_PORT}`;
 const GATEWAY_ORIGIN = `http://${GATEWAY_HOST}`;
 const UMBREL_OWNER = "umbrel-owner";
@@ -93,15 +96,21 @@ function writeEnv(env) {
     }
   }
   fs.writeFileSync(ENV_FILE, lines.join("\n") + "\n", { mode: 0o600 });
+  fs.chmodSync(ENV_FILE, 0o600);
 }
 
 function writeConfig(config) {
   fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), { mode: 0o600 });
+  fs.chmodSync(CONFIG_FILE, 0o600);
 }
 
 function ensureConfigDir() {
   if (!fs.existsSync(CONFIG_DIR)) {
-    fs.mkdirSync(CONFIG_DIR, { recursive: true });
+    fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  }
+  fs.chmodSync(CONFIG_DIR, 0o700);
+  for (const file of [CONFIG_FILE, ENV_FILE]) {
+    if (fs.existsSync(file)) fs.chmodSync(file, 0o600);
   }
   const workspaceDir = path.join(CONFIG_DIR, "workspace");
   if (!fs.existsSync(workspaceDir)) {
@@ -467,14 +476,45 @@ function reconcileConfig() {
     config.gateway.trustedProxies = ["127.0.0.1/32"];
     changed = true;
   }
+  if (!config.gateway.nodes || typeof config.gateway.nodes !== "object" || Array.isArray(config.gateway.nodes)) {
+    config.gateway.nodes = {};
+  }
+  if (!config.gateway.nodes.pairing || typeof config.gateway.nodes.pairing !== "object" || Array.isArray(config.gateway.nodes.pairing)) {
+    config.gateway.nodes.pairing = {};
+  }
+  // The native listener is a loopback proxy, so the Gateway cannot infer that
+  // its caller is remote. Require explicit device approval instead of applying
+  // OpenClaw's ordinary direct-loopback auto-approval policy.
+  if (config.gateway.nodes.pairing.autoApproveLocal !== false) {
+    config.gateway.nodes.pairing.autoApproveLocal = false;
+    changed = true;
+  }
   if ("token" in config.gateway.auth) {
     delete config.gateway.auth.token;
     changed = true;
   }
 
-  // Direct internal CLI/RPC clients use a password without passing through the
-  // browser proxy. Preserve supported password SecretRefs across restarts.
+  // Direct CLI/RPC and native clients use a password without passing through
+  // the browser proxy. On Umbrel, use the app's deterministic password so the
+  // owner can retrieve the credential from the ordinary app settings. This
+  // intentionally replaces the legacy generated token, which was not usable
+  // through umbrelOS' authenticated app proxy.
   const env = readEnv();
+  const previousEnv = JSON.stringify(env);
+  if (process.env.UMBREL_OPENCLAW_REMOTE_PASSWORD) {
+    const passwordRef = {
+      source: "env",
+      provider: "default",
+      id: "OPENCLAW_GATEWAY_PASSWORD",
+    };
+    if (JSON.stringify(config.gateway.auth.password) !== JSON.stringify(passwordRef)) {
+      config.gateway.auth.password = passwordRef;
+      changed = true;
+    }
+    if (env.OPENCLAW_GATEWAY_PASSWORD !== process.env.UMBREL_OPENCLAW_REMOTE_PASSWORD) {
+      env.OPENCLAW_GATEWAY_PASSWORD = process.env.UMBREL_OPENCLAW_REMOTE_PASSWORD;
+    }
+  }
   let password = resolveGatewaySecretValue(config.gateway.auth.password, env);
   if (!password) {
     config.gateway.auth.password = crypto.randomBytes(24).toString("hex");
@@ -492,7 +532,6 @@ function reconcileConfig() {
     writeConfig(config);
   }
 
-  const previousEnv = JSON.stringify(env);
   delete env.OPENCLAW_GATEWAY_TOKEN;
   if (config.gateway.auth.password?.source === "env" &&
       config.gateway.auth.password.id !== "OPENCLAW_GATEWAY_PASSWORD") {
@@ -941,6 +980,142 @@ function handleUpgrade(req, socket, head) {
   });
 }
 
+function getNativeGatewayProxyHeaders(req) {
+  if (req.method !== "GET" || String(req.headers.upgrade || "").toLowerCase() !== "websocket") {
+    return null;
+  }
+  const headers = {};
+  for (const [name, value] of Object.entries(req.headers)) {
+    const key = name.toLowerCase();
+    if (key.startsWith("x-forwarded-") || key.startsWith("x-umbrel-") ||
+        key.startsWith("tailscale-") || key.startsWith("x-tailscale-") ||
+        key.startsWith("sec-websocket-") ||
+        ["connection", "content-length", "cookie", "forwarded", "host", "upgrade",
+          "origin", "x-real-ip", "authorization", "proxy-authorization"].includes(key)) {
+      continue;
+    }
+    headers[key] = value;
+  }
+  // The native relay necessarily reaches the Gateway over loopback. Supplying
+  // a fixed, allowed Origin makes OpenClaw apply its browser-context pairing
+  // protections and prevents remote callers from inheriting privileged
+  // no-Origin loopback exceptions. Never forward a caller-controlled Origin.
+  headers.origin = GATEWAY_ORIGIN;
+  return headers;
+}
+
+function translateNativeConnectFrame(data, isBinary) {
+  const byteLength = Buffer.isBuffer(data) ? data.length : Buffer.byteLength(data);
+  if (isBinary || byteLength > GATEWAY_MAX_PREAUTH_PAYLOAD_BYTES) return null;
+  try {
+    const frame = JSON.parse(data.toString());
+    if (frame?.type !== "req" || frame?.method !== "connect" || !frame.params) {
+      return null;
+    }
+    if (!frame.params.auth || typeof frame.params.auth !== "object" ||
+        typeof frame.params.auth.token !== "string" || frame.params.auth.password) {
+      return data;
+    }
+    frame.params.auth.password = frame.params.auth.token;
+    return JSON.stringify(frame);
+  } catch {
+    return null;
+  }
+}
+
+const nativeWss = new WebSocket.Server({
+  noServer: true,
+  maxPayload: GATEWAY_MAX_PAYLOAD_BYTES,
+});
+
+// Native clients cannot complete umbrelOS browser authentication. This second,
+// WebSocket-only listener passes their Gateway credential and device identity to
+// OpenClaw without injecting the Umbrel owner's trusted-proxy identity. Current
+// native apps label the only credential field "token"; trusted-proxy fallback
+// accepts a password credential in auth.password, so add that alias while
+// retaining auth.token for the device-signature payload. The caller-supplied
+// value remains unchanged and the Gateway still validates it.
+function handleNativeUpgrade(req, socket, head) {
+  const headers = getNativeGatewayProxyHeaders(req);
+  if (!headers) {
+    socket.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
+    return;
+  }
+  if (!isConfigured() || ptyProcess) {
+    socket.end("HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\n");
+    return;
+  }
+  if (!openclawProcess) startOpenclaw();
+
+  nativeWss.handleUpgrade(req, socket, head, (client) => {
+    const upstream = new WebSocket(`ws://${GATEWAY_HOST}${req.url || "/"}`, { headers });
+    let connectForwarded = false;
+    let closedByClient = false;
+
+    client.on("message", (data, isBinary) => {
+      let outbound = data;
+      if (!connectForwarded) {
+        outbound = translateNativeConnectFrame(data, isBinary);
+        if (outbound == null) {
+          const byteLength = Buffer.isBuffer(data) ? data.length : Buffer.byteLength(data);
+          const code = byteLength > GATEWAY_MAX_PREAUTH_PAYLOAD_BYTES ? 1009 : 1008;
+          client.close(code, "First message must be a valid Gateway connect request");
+          closedByClient = true;
+          upstream.close();
+          return;
+        }
+        connectForwarded = true;
+      }
+      if (upstream.readyState !== WebSocket.OPEN) {
+        client.close(1013, "Gateway is starting");
+        closedByClient = true;
+        upstream.close();
+        return;
+      }
+      upstream.send(outbound, { binary: isBinary });
+    });
+    upstream.on("message", (data, isBinary) => {
+      if (client.readyState === WebSocket.OPEN) client.send(data, { binary: isBinary });
+    });
+
+    upstream.on("close", (code, reason) => {
+      if (client.readyState !== WebSocket.OPEN) return;
+      if (code === 1006) client.terminate();
+      else client.close(code, reason);
+    });
+    client.on("close", (code, reason) => {
+      closedByClient = true;
+      if (upstream.readyState === WebSocket.CONNECTING) upstream.close();
+      else if (upstream.readyState === WebSocket.OPEN) {
+        if (code === 1006) upstream.terminate();
+        else upstream.close(code, reason);
+      }
+    });
+    upstream.on("error", (err) => {
+      if (!closedByClient && err.code !== "ECONNREFUSED") {
+        console.error("Native Gateway upstream error:", err.message);
+      }
+      if (client.readyState === WebSocket.OPEN) client.close(1013, "Gateway is starting");
+    });
+    client.on("error", (err) => {
+      console.error("Native Gateway client error:", err.message);
+      upstream.terminate();
+    });
+  });
+}
+
+const nativeGatewayServer = http.createServer((_req, res) => {
+  res.writeHead(426, {
+    "Content-Type": "text/plain",
+    "Cache-Control": "no-store",
+    "Connection": "close",
+    "Upgrade": "websocket",
+  });
+  res.end("This endpoint accepts authenticated OpenClaw Gateway WebSocket connections only.\n");
+});
+
+nativeGatewayServer.on("upgrade", handleNativeUpgrade);
+
 const server = http.createServer((req, res) => {
   if (!isAllowedBrowserRequest(req)) {
     res.writeHead(403, { "Content-Type": "text/plain" });
@@ -1156,6 +1331,9 @@ async function main() {
   server.listen(PORT, "0.0.0.0", () => {
     console.log(`Setup server listening on port ${PORT}`);
   });
+  nativeGatewayServer.listen(NATIVE_GATEWAY_PORT, "0.0.0.0", () => {
+    console.log(`Native Gateway WebSocket listener available on port ${NATIVE_GATEWAY_PORT}`);
+  });
 }
 
 // Graceful shutdown: Docker sends SIGTERM on stop/restart/update.
@@ -1175,6 +1353,7 @@ function shutdown() {
     openclawProcess.kill("SIGTERM");
   }
   server.close();
+  nativeGatewayServer.close();
 }
 
 if (require.main === module) {
@@ -1185,4 +1364,11 @@ if (require.main === module) {
   process.on("SIGTERM", shutdown);
 }
 
-module.exports = { reconcileConfig, getOpenClawEnv, getGatewayProxyHeaders, isAllowedBrowserRequest };
+module.exports = {
+  reconcileConfig,
+  getOpenClawEnv,
+  getGatewayProxyHeaders,
+  getNativeGatewayProxyHeaders,
+  translateNativeConnectFrame,
+  isAllowedBrowserRequest,
+};

--- a/test/server.test.cjs
+++ b/test/server.test.cjs
@@ -8,13 +8,21 @@ const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wrapper-test-")
 const configFile = path.join(stateDir, "openclaw.json");
 const envFile = path.join(stateDir, ".env");
 process.env.OPENCLAW_STATE_DIR = stateDir;
-const { reconcileConfig, getOpenClawEnv, getGatewayProxyHeaders, isAllowedBrowserRequest } = require("../server.cjs");
+const {
+  reconcileConfig,
+  getOpenClawEnv,
+  getGatewayProxyHeaders,
+  getNativeGatewayProxyHeaders,
+  translateNativeConnectFrame,
+  isAllowedBrowserRequest,
+} = require("../server.cjs");
 
 beforeEach(() => {
   fs.writeFileSync(configFile, JSON.stringify({ wizard: { lastRunVersion: "2026.7.1-2" } }));
   fs.writeFileSync(envFile, "");
   delete process.env.OPENCLAW_GATEWAY_TOKEN;
   delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+  delete process.env.UMBREL_OPENCLAW_REMOTE_PASSWORD;
 });
 after(() => fs.rmSync(stateDir, { recursive: true, force: true }));
 
@@ -35,6 +43,8 @@ test("migrates legacy token auth while retaining user settings and a stable inte
   process.env.OPENCLAW_GATEWAY_PASSWORD = "inherited-stale-password";
   reconcileConfig();
   const result = JSON.parse(fs.readFileSync(configFile));
+  assert.equal(fs.statSync(configFile).mode & 0o777, 0o600);
+  assert.equal(fs.statSync(envFile).mode & 0o777, 0o600);
   assert.deepEqual(result.agents, config.agents);
   assert.deepEqual(result.channels, config.channels);
   assert.deepEqual(result.wizard, config.wizard);
@@ -45,6 +55,7 @@ test("migrates legacy token auth while retaining user settings and a stable inte
   assert.equal(result.gateway.controlUi.basePath, "/");
   assert.ok(result.gateway.controlUi.allowedOrigins.includes("http://127.0.0.1:18790"));
   assert.deepEqual(result.gateway.trustedProxies, ["127.0.0.1/32"]);
+  assert.equal(result.gateway.nodes.pairing.autoApproveLocal, false);
   assert.deepEqual(result.gateway.auth.identityScopes, { "umbrel-owner": ["operator.admin"] });
   assert.equal(result.gateway.auth.trustedProxy.allowLoopback, true);
   assert.equal(result.gateway.auth.trustedProxy.deviceAutoApprove.enabled, true);
@@ -70,6 +81,38 @@ test("preserves env-backed passwords without stale overrides or losing provider 
   assert.deepEqual(JSON.parse(fs.readFileSync(configFile)).gateway.auth.password, password);
   assert.doesNotMatch(fs.readFileSync(envFile, "utf8"), /^OPENCLAW_GATEWAY_PASSWORD=/m);
   assert.equal(getOpenClawEnv().OPENCLAW_GATEWAY_PASSWORD, "current-password");
+});
+
+test("uses Umbrel's deterministic app password for new direct-client credentials", () => {
+  process.env.UMBREL_OPENCLAW_REMOTE_PASSWORD = "test-umbrel-password";
+  reconcileConfig();
+  const config = JSON.parse(fs.readFileSync(configFile));
+  assert.deepEqual(config.gateway.auth.password, {
+    source: "env",
+    provider: "default",
+    id: "OPENCLAW_GATEWAY_PASSWORD",
+  });
+  assert.equal(getOpenClawEnv().OPENCLAW_GATEWAY_PASSWORD, "test-umbrel-password");
+  assert.match(fs.readFileSync(envFile, "utf8"), /^OPENCLAW_GATEWAY_PASSWORD=test-umbrel-password$/m);
+});
+
+test("rotates an unreachable legacy token to Umbrel's discoverable app password", () => {
+  fs.writeFileSync(configFile, JSON.stringify({ gateway: { auth: {
+    mode: "token",
+    token: "legacy-wrapper-token",
+  } } }));
+  fs.writeFileSync(envFile, "OPENCLAW_GATEWAY_TOKEN=legacy-wrapper-token\n");
+  process.env.UMBREL_OPENCLAW_REMOTE_PASSWORD = "test-umbrel-password";
+  reconcileConfig();
+  const config = JSON.parse(fs.readFileSync(configFile));
+  assert.deepEqual(config.gateway.auth.password, {
+    source: "env",
+    provider: "default",
+    id: "OPENCLAW_GATEWAY_PASSWORD",
+  });
+  assert.equal(config.gateway.auth.token, undefined);
+  assert.equal(getOpenClawEnv().OPENCLAW_GATEWAY_PASSWORD, "test-umbrel-password");
+  assert.doesNotMatch(fs.readFileSync(envFile, "utf8"), /OPENCLAW_GATEWAY_TOKEN=/);
 });
 
 test("enforces supervisor environment even when the persisted environment overrides it", () => {
@@ -153,4 +196,58 @@ test("uses socket attribution and refuses invented client addresses for local wr
     assert.equal(getGatewayProxyHeaders(request({ "x-forwarded-for": "192.0.2.1" }, { socket: { remoteAddress } })), null);
   }
   assert.equal(getGatewayProxyHeaders(request({}, { socket: { remoteAddress: "fd00::2" } }))["x-forwarded-for"], "fd00::2");
+});
+
+test("native Gateway proxy preserves WebSocket protocol data but strips ambient and spoofed identity", () => {
+  const headers = getNativeGatewayProxyHeaders(request({
+    upgrade: "websocket",
+    connection: "Upgrade",
+    origin: "https://native.example",
+    cookie: "umbrel=secret",
+    authorization: "Bearer should-not-cross",
+    "proxy-authorization": "secret",
+    "x-umbrel-user": "umbrel-owner",
+    "x-umbrel-custom": "spoofed",
+    "x-forwarded-for": "127.0.0.1",
+    "x-forwarded-proto": "https",
+    "x-real-ip": "127.0.0.1",
+    forwarded: "for=127.0.0.1",
+    "tailscale-user-login": "owner@example.com",
+    "x-tailscale-user-login": "owner@example.com",
+    "sec-websocket-key": "test-key",
+    "sec-websocket-version": "13",
+  }));
+  assert.equal(headers.host, undefined);
+  assert.equal(headers.origin, "http://127.0.0.1:18790");
+  assert.equal(headers["sec-websocket-key"], undefined);
+  for (const key of [
+    "cookie", "authorization", "proxy-authorization", "x-umbrel-user", "x-umbrel-custom",
+    "x-forwarded-for", "x-forwarded-proto", "x-real-ip", "forwarded",
+    "tailscale-user-login", "x-tailscale-user-login",
+  ]) {
+    assert.equal(headers[key], undefined, key);
+  }
+});
+
+test("native Gateway proxy accepts only WebSocket GET upgrades", () => {
+  assert.equal(getNativeGatewayProxyHeaders(request({ upgrade: "h2c" })), null);
+  assert.equal(getNativeGatewayProxyHeaders(request({ upgrade: "websocket" }, { method: "POST" })), null);
+});
+
+test("native Gateway proxy maps the app's token field to password auth without changing its value", () => {
+  const frame = {
+    type: "req",
+    id: "connect",
+    method: "connect",
+    params: { auth: { token: "caller-supplied-secret" }, client: { id: "openclaw-macos" } },
+  };
+  const translated = JSON.parse(translateNativeConnectFrame(Buffer.from(JSON.stringify(frame)), false));
+  assert.equal(translated.params.auth.password, "caller-supplied-secret");
+  assert.equal(translated.params.auth.token, "caller-supplied-secret");
+  assert.deepEqual(translated.params.client, frame.params.client);
+
+  assert.equal(translateNativeConnectFrame(Buffer.from("not-json"), false), null);
+  assert.equal(translateNativeConnectFrame(Buffer.from("binary"), true), null);
+  assert.equal(translateNativeConnectFrame(Buffer.alloc(64 * 1024 + 1), false), null);
+  assert.equal(translateNativeConnectFrame(Buffer.from(JSON.stringify({ type: "req", method: "health" })), false), null);
 });


### PR DESCRIPTION
## Summary

Add a separate, authenticated WebSocket-only listener for native OpenClaw clients while preserving umbrelOS authentication for browser access.

This is the wrapper half of getumbrel/umbrel-apps#6072. A follow-up `umbrel-apps` change will keep the browser UI behind `app_proxy` on its existing host port `18789` and publish the native listener on host port `18791`.

## Design

- Keep the OpenClaw Gateway bound to container loopback on `18790`.
- Keep the browser wrapper on `18789`, with Umbrel trusted-proxy identity, same-origin checks, and browser device enrollment unchanged.
- Add a native WebSocket-only listener on `18791`.
- Strip Umbrel identity, forwarding, cookie, HTTP authorization, Tailscale, and WebSocket-handshake headers before opening a fresh internal Gateway connection. Replace the caller's Origin with the fixed, allowlisted internal Gateway Origin.
- Authenticate native clients with Umbrel's deterministic app password. The macOS app currently labels its only credential field as `token`, so the relay aliases that caller-supplied value into `auth.password` while retaining the original token field for the signed device payload.
- Require explicit device/node approval because the internal relay necessarily appears to OpenClaw as a loopback caller.
- Accept only a text Gateway `connect` request as the first client frame, using OpenClaw's 64 KiB pre-auth and 25 MiB post-auth payload limits.
- Restrict the persisted config directory and credential files to owner-only permissions.

No credential or owner identity is injected into a native connection. OpenClaw performs password validation, device authentication, pairing, scope enforcement, and node-capability approval.

## Security boundary

The native listener is intended for a private LAN or Tailnet. It deliberately returns `426 Upgrade Required` to ordinary HTTP requests and should not be forwarded directly to the public Internet: `ws://` is plaintext and the Gateway is a high-authority control surface. Public-network access should use a properly authenticated TLS endpoint (`wss://`).

The relay supplies a fixed internal Origin rather than forwarding a caller-controlled value. This makes OpenClaw apply its browser-context pairing protections and prevents remote connections relayed over loopback from reaching the no-Origin backend self-pairing exception described in openclaw/openclaw#72418. `gateway.nodes.pairing.autoApproveLocal` is also forced off as defense in depth.

One limitation is that OpenClaw sees native relay connections as the same loopback peer, so its authentication-failure rate limit is shared by native clients. A hostile private-network peer could cause a temporary login lockout for other native clients, but this does not bypass authentication. Preserving the real peer address would make the trusted-proxy password fallback unavailable in the current OpenClaw release.

The browser and native paths remain separate:

- browser path: umbrelOS `app_proxy` authentication -> wrapper trusted identity -> loopback Gateway
- native path: caller password + signed device identity -> explicit pairing -> loopback Gateway

No Tailscale app changes or host-level configuration are required.

## Verification

- `node --check server.cjs`
- `npm test` (15 passed; 1 image-only test skipped on the host)
- wrapper image tests (16 passed)
- existing browser integration suite (6 passed)
- native probe rejects forged identity/proxy headers without a valid credential
- image-level native probe reaches pairing when the configured Umbrel app password is supplied
- native probe confirms that a password-authenticated client impersonating `gateway-client` / `backend` still requires pairing
- ordinary HTTP requests to the native listener receive `426 Upgrade Required`
- tested on an existing Umbrel installation without replacing its data volume
- native macOS client connected using `ws://umbrel.local:18791`
- the listener was reachable through the Umbrel's LAN and Tailscale IP addresses
- browser access remained protected by umbrelOS authentication
- app restart preserved both browser and native access

## Upgrade behavior

Existing OpenClaw settings and provider credentials are retained. The wrapper removes the retired token setting and, on Umbrel, rotates the previously undiscoverable direct-client credential to the app's deterministic password so the owner can retrieve it from app settings.

The `umbrel-apps` update must be merged only after a wrapper image containing this change has been published and pinned by digest.
